### PR TITLE
[minigraph.py] generate mandatory default port description

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -530,12 +530,25 @@ def parse_xml(filename, platform=None, port_config_file=None):
         if port.get('speed') == '100000':
             port['fec'] = 'rs'
 
+    # set port description if parsed from deviceinfo
     for port_name in port_descriptions:
         # ignore port not in port_config.ini
         if not ports.has_key(port_name):
             continue
 
         ports.setdefault(port_name, {})['description'] = port_descriptions[port_name]
+
+    # for the ports w/o description try to set one based on neighbor info, or just " "
+    for port_name, port in ports.items():
+        if not port.get('description'):
+            try:
+                neigh_host = neighbors[port_name]['name']
+                neigh_port = neighbors[port_name]['port']
+                port.setdefault('description', neigh_host + ':' + neigh_port)
+            except KeyError:
+                pass
+            # if no meaningful description available, set to default (a space)
+            port.setdefault('description', ' ')
 
     # set default port MTU as 9100
     for port in ports.itervalues():

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -538,17 +538,17 @@ def parse_xml(filename, platform=None, port_config_file=None):
 
         ports.setdefault(port_name, {})['description'] = port_descriptions[port_name]
 
-    # for the ports w/o description try to set one based on neighbor info, or just " "
+    # for the ports w/o description try to set one based on neighbor info, or just port name by default
     for port_name, port in ports.items():
         if not port.get('description'):
             try:
                 neigh_host = neighbors[port_name]['name']
                 neigh_port = neighbors[port_name]['port']
-                port.setdefault('description', neigh_host + ':' + neigh_port)
+                port['description'] = neigh_host + ':' + neigh_port
             except KeyError:
                 pass
-            # if no meaningful description available, set to default (a space)
-            port.setdefault('description', ' ')
+            # if no neighbor info available, set to port name
+            port.setdefault('description', port_name)
 
     # set default port MTU as 9100
     for port in ports.itervalues():


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add logic to always generate port description for PORT. The goal is to provide the description in one place for snmp, lldp and user. (previously lldpmgr generated its own port description)
**- How I did it**
The logic is the following:
If the port description is specified in port_config.ini - use it.
If the minigraph has info about the neighbor for this port - create description in form "{neighbor_host}:{neighbor_port}"
Else assign default - " ".
**- How to verify it**
sonic-cfggen -m /etc/sonic/minigraph.xml -p  /usr/share/sonic/device/x86_64-mlnx_msn2100-r0/ACS-MSN2100/port_config.ini --print-data

port_config.ini
```
# name          lanes         speed description
Ethernet0       0             10000   q
Ethernet1       1             10000
Ethernet2       2             10000   w
```
```
Result :
    "PORT": {
        "Ethernet0": {
            "lanes": "0",
            "alias": "Ethernet0",
            "speed": "10000",
            "description": "q",
            "mtu": "9100"
        },
        "Ethernet1": {
            "lanes": "1",
            "description": "Servers0:eth0",
            "mtu": "9100",
            "alias": "Ethernet1",
            "admin_status": "up",
            "speed": "10000"
        },
        "Ethernet2": {
            "lanes": "2",
            "description": "w",
            "mtu": "9100",
            "alias": "Ethernet2",
            "admin_status": "up",
            "speed": "10000"
 . . .
        "Ethernet36": {
            "lanes": "36,37,38,39",
            "description": "ARISTA04T1:Ethernet1",
            "mtu": "9100",
            "alias": "Ethernet36",
            "admin_status": "up",
            "speed": "50000"
        },
        "Ethernet40": {
            "alias": "Ethernet40",
            "lanes": "40,41,42,43",
            "description": " ",
            "speed": "40000",
            "mtu": "9100"
        }
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
generate mandatory default port description

**- A picture of a cute animal (not mandatory but encouraged)**
